### PR TITLE
Json-driven frame size for simulation

### DIFF
--- a/yagsl/java/swervelib/SwerveDrive.java
+++ b/yagsl/java/swervelib/SwerveDrive.java
@@ -241,10 +241,10 @@ public class SwerveDrive implements AutoCloseable
     {
       DriveTrainSimulationConfig simulationConfig = DriveTrainSimulationConfig.Default()
                                                                               .withBumperSize(
-                                                                                  Meters.of(config.getTracklength())
-                                                                                        .plus(Inches.of(5)),
-                                                                                  Meters.of(config.getTrackwidth())
-                                                                                        .plus(Inches.of(5)))
+                                                                                  Inches.of(config.physicalCharacteristics.frameSize.length)
+                                                                                        .plus(Inches.of(config.physicalCharacteristics.frameSize.bumperThickness)),
+                                                                                  Inches.of(config.physicalCharacteristics.frameSize.width)
+                                                                                        .plus(Inches.of(config.physicalCharacteristics.frameSize.bumperThickness)))
                                                                               .withRobotMass(Kilograms.of(config.physicalCharacteristics.robotMassKg))
                                                                               .withCustomModuleTranslations(config.moduleLocationsMeters)
                                                                               .withGyro(config.getGyroSim())

--- a/yagsl/java/swervelib/parser/SwerveModulePhysicalCharacteristics.java
+++ b/yagsl/java/swervelib/parser/SwerveModulePhysicalCharacteristics.java
@@ -1,5 +1,6 @@
 package swervelib.parser;
 
+import swervelib.parser.json.FrameSizeJson;
 import swervelib.parser.json.modules.ConversionFactorsJson;
 
 /**
@@ -32,6 +33,10 @@ public class SwerveModulePhysicalCharacteristics
    * Robot mass in Kilograms.
    */
   public final double                robotMassKg;
+  /**
+   * The width of the robot frame in meters.
+   */
+  public final FrameSizeJson         frameSize;   
   /**
    * The voltage to use for the smart motor voltage compensation.
    */
@@ -75,7 +80,8 @@ public class SwerveModulePhysicalCharacteristics
       double driveFrictionVoltage,
       double angleFrictionVoltage,
       double steerRotationalInertia,
-      double robotMassKg)
+      double robotMassKg,
+      FrameSizeJson frameSize)
   {
     this.wheelGripCoefficientOfFriction = wheelGripCoefficientOfFriction;
     this.optimalVoltage = optimalVoltage;
@@ -98,6 +104,7 @@ public class SwerveModulePhysicalCharacteristics
     this.angleFrictionVoltage = angleFrictionVoltage;
     this.steerRotationalInertia = steerRotationalInertia;
     this.robotMassKg = robotMassKg;
+    this.frameSize = frameSize;
   }
 
   /**
@@ -116,7 +123,8 @@ public class SwerveModulePhysicalCharacteristics
   public SwerveModulePhysicalCharacteristics(
       ConversionFactorsJson conversionFactors,
       double driveMotorRampRate,
-      double angleMotorRampRate)
+      double angleMotorRampRate,
+      FrameSizeJson frameSize)
   {
     this(
         conversionFactors,
@@ -129,6 +137,7 @@ public class SwerveModulePhysicalCharacteristics
         0.2,
         0.3,
         0.03,
-        50);
+        50,
+        frameSize);
   }
 }

--- a/yagsl/java/swervelib/parser/json/FrameSizeJson.java
+++ b/yagsl/java/swervelib/parser/json/FrameSizeJson.java
@@ -1,0 +1,41 @@
+package swervelib.parser.json;
+
+/**
+ * Used to store frame size.
+ */
+public class FrameSizeJson {
+
+  /**
+   * Frame length in inches.
+   */
+  public double length;
+  /**
+   * Frame width in inches.
+   */
+  public double width;
+  /**
+   * Bumper width in inches.
+   */
+  public double bumperThickness;
+
+  /**
+   * Default constructor.
+   */
+  public FrameSizeJson() 
+  {
+  }
+
+  /**
+   * Default Constructor.
+   *
+   * @param length Frame length in inches.
+   * @param width  Frame width in inches.
+   * @param bumperThickness Bumper thickness in inches.
+   */
+  public FrameSizeJson(double length, double width, double bumperThickness) 
+  {
+    this.length = length;
+    this.width = width;
+    this.bumperThickness = bumperThickness;
+  }
+}

--- a/yagsl/java/swervelib/parser/json/PhysicalPropertiesJson.java
+++ b/yagsl/java/swervelib/parser/json/PhysicalPropertiesJson.java
@@ -51,6 +51,10 @@ public class PhysicalPropertiesJson
    * The voltage to use for the smart motor voltage compensation, default is 12.
    */
   public double                optimalVoltage                 = 12;
+  /**
+   * Frame size of the robot in inches, default is 30in x 30in with 5in bumper thickness.
+   */
+  public FrameSizeJson         frameSize                      = new FrameSizeJson(30.0, 30.0, 5.0);
 
   /**
    * Create the physical characteristics based off the parsed data.
@@ -81,7 +85,8 @@ public class PhysicalPropertiesJson
         friction.drive,
         friction.angle,
         steerRotationalInertia,
-        Pounds.of(robotMass).in(Kilogram));
+        Pounds.of(robotMass).in(Kilogram),
+        frameSize);
   }
 }
 


### PR DESCRIPTION
- Added FrameSizeJson to the Physical properties containing the frame length, frame width, and bumper thickness. Defaults to 30"x30" frame with 5" bumpers