### PR TITLE
Updates to Thrifty API for ThriftyNova code

### DIFF
--- a/yagsl/java/swervelib/encoders/ThriftyNovaEncoderSwerve.java
+++ b/yagsl/java/swervelib/encoders/ThriftyNovaEncoderSwerve.java
@@ -42,14 +42,19 @@ public class ThriftyNovaEncoderSwerve extends SwerveAbsoluteEncoder
    * motor.
    *
    * @param motor {@link SwerveMotor} through which to interface with the attached encoder .
+   * @param encoderType the type of encoder to use (options: "REV_ENCODER", "REDUX_ENCODER", "SRX_MAG_ENCODER")
    */
   public ThriftyNovaEncoderSwerve(SwerveMotor motor, String encoderType)
   {
     this.motor = (ThriftyNova) motor.getMotor();
-    positionConversion = new Conversion(PositionUnit.DEGREES, EncoderType.ABS);
     velocityConversion = new Conversion(VelocityUnit.DEGREES_PER_SEC, EncoderType.ABS);
-    this.motor.setExternalEncoder(ExternalEncoder.valueOf(encoderType));
-    this.motor.useEncoderType(EncoderType.ABS);
+    positionConversion = new Conversion(PositionUnit.DEGREES, EncoderType.ABS);
+    ExternalEncoder externalEncoderType = ExternalEncoder.valueOf(encoderType);
+    this.motor.setExternalEncoder(externalEncoderType);
+    setAbsoluteEncoderOffset(offset);
+    if (ExternalEncoder.REDUX_ENCODER == externalEncoderType) {
+      this.motor.setAbsoluteWrapping(true);
+    }
   }
 
   @Override
@@ -95,9 +100,9 @@ public class ThriftyNovaEncoderSwerve extends SwerveAbsoluteEncoder
   @Override
   public double getAbsolutePosition()
   {
-    double rawMotor = motor.getPosition();
-    double convertedMotor = positionConversion.fromMotor(rawMotor);
-    return (convertedMotor + offset) * (inverted ? -1.0 : 1.0);
+    double rawMotor = motor.getPositionAbs();
+    double convertedPosition = positionConversion.fromMotor(rawMotor);
+    return convertedPosition * (inverted ? -1.0 : 1.0);
   }
 
   /**
@@ -119,6 +124,7 @@ public class ThriftyNovaEncoderSwerve extends SwerveAbsoluteEncoder
   public boolean setAbsoluteEncoderOffset(double offset)
   {
     this.offset = offset;
+    motor.setAbsOffset((int) offset);
     return true;
   }
 

--- a/yagsl/java/swervelib/motors/ThriftyNovaSwerve.java
+++ b/yagsl/java/swervelib/motors/ThriftyNovaSwerve.java
@@ -165,20 +165,7 @@ public class ThriftyNovaSwerve extends SwerveMotor
     {
       if (RobotBase.isReal())
       {
-        motor.setInverted(false);
-        motor.setBrakeMode(false);
-        setCurrentLimit(40);
-        motor.setEncoderPosition(0);
-        motor.setMaxOutput(1.0);
-        motor.setRampDown(100);
-        motor.setRampUp(100);
-        configureCANStatusFrames(0.25, 0.1, 0.25, 0.5, 0.50);
-        motor.setSoftLimits(0, 0);
-        configurePIDF(new PIDFConfig());
-        motor.pid1.setP(0)
-                  .setI(0)
-                  .setD(0)
-                  .setFF(0.0);
+        motor.factoryReset();
       }
       factoryDefaultOccurred = true;
     }


### PR DESCRIPTION
Uses the new factory reset on the motors, sets the correct encoder type and wrapping, uses the new getPositionAbs to get the absolute encoder position separate from the motor encoder.