### PR TITLE
feat: An offset can be added to the aiming functionality

### DIFF
--- a/yagsl/java/swervelib/SwerveInputStream.java
+++ b/yagsl/java/swervelib/SwerveInputStream.java
@@ -272,6 +272,8 @@ public class SwerveInputStream implements Supplier<ChassisSpeeds>
     this.aimLookaheadTime = s.aimLookaheadTime;
     this.azimuthFeedforward = s.azimuthFeedforward;
     this.aimGoalAngle = s.aimGoalAngle;
+    this.aimHeadingOffset = s.aimHeadingOffset;
+    this.aimHeadingOffsetEnabled = s.aimHeadingOffsetEnabled;
   }
 
   /**
@@ -1039,15 +1041,8 @@ public class SwerveInputStream implements Supplier<ChassisSpeeds>
    */
   public AngularVelocity calculateAngularVelocity(Angle target)
   {
-    double offsetRadians = 0;
-
-    if (translationHeadingOffsetEnabled.isPresent() && translationHeadingOffsetEnabled.get().getAsBoolean()&&translationHeadingOffset.isPresent())
-    {
-      offsetRadians = translationHeadingOffset.get().getRadians();
-    }
-    
     var omegaRadiansPerSecond = swerveController.headingCalculate(swerveDrive.getOdometryHeading().getRadians(),
-                                                                  target.in(Radians) + offsetRadians);
+                                                                  target.in(Radians));
     if (azimuthFeedforward.isPresent())
     {
       omegaRadiansPerSecond += azimuthFeedforward.get()


### PR DESCRIPTION
This allows bots to aim at a target with more than just the front of the robot.

### Added functions to SwerveInputStream:
- aimOffset(rotation2d), sets the offset and stores it within the SIS
- aimOffset(boolean), sets wither the offset is enabled or not
- aimOffset(BooleanSupplier), sets wither the offset is enabled or not using a boolean supplier

### Added class vars:
- aimOffset: Optional<Rotation2d>, the offset to be applied
- aimOffsetEnabled: Optional<BooleanSupplier>, getter function for enabled state