### PR TITLE
Adds overrides to activity when shouldClock is set to false. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,4 +74,3 @@ SwerveDrive swerveDrive=new SwerveParser(new File(Filesystem.getDeployDirectory(
 # Special Thanks to Team 7900! Trial N' Terror
 Without the debugging and aid of Team 7900 the project could never be as stable or active as it is.
 Falcon Support would not have been possible without support from Team 1466 Webb Robotics!
-


### PR DESCRIPTION
Users are now able to set weather a hub will be inactive or active when they configure the 2026Arena to not time activity itself. 