### PR TITLE
Change aimTarget to use Supplier<Pose2d>

### DIFF
--- a/yagsl/java/swervelib/SwerveInputStream.java
+++ b/yagsl/java/swervelib/SwerveInputStream.java
@@ -255,7 +255,7 @@ public class SwerveInputStream implements Supplier<ChassisSpeeds>
     this.driveToPose = s.driveToPose;
     this.driveToPoseTranslationPIDController = s.driveToPoseTranslationPIDController;
     this.driveToPoseOmegaPIDController = s.driveToPoseOmegaPIDController;
-    this.aimTarget = s.aimTarget;
+    this. = s.aimTarget;
     this.headingEnabled = s.headingEnabled;
     this.aimEnabled = s.aimEnabled;
     this.driveToPoseEnabled = s.driveToPoseEnabled;
@@ -574,6 +574,13 @@ public class SwerveInputStream implements Supplier<ChassisSpeeds>
     return this;
   }
 
+  
+   /**
+   * Aim the {@link SwerveDrive} at this pose while driving.
+   *
+   * @param aimTarget {@link Supplier<Pose2d>} to point at.
+   * @return this
+   */
   public SwerveInputStream aim(Supplier<Pose2d> aimTarget)
   {
     this.aimTarget = aimTarget.get().equals(Pose2d.kZero) ? Optional.empty() : Optional.of(aimTarget);

--- a/yagsl/java/swervelib/SwerveInputStream.java
+++ b/yagsl/java/swervelib/SwerveInputStream.java
@@ -96,7 +96,7 @@ public class SwerveInputStream implements Supplier<ChassisSpeeds>
   /**
    * Target to aim at.
    */
-  private       Optional<Pose2d>                 aimTarget                           = Optional.empty();
+  private       Optional<Supplier<Pose2d>>                 aimTarget                           = Optional.empty();
   /**
    * Target {@link Supplier<Pose2d>} to drive towards when driveToPose is enabled.
    */
@@ -568,9 +568,15 @@ public class SwerveInputStream implements Supplier<ChassisSpeeds>
    * @param aimTarget {@link Pose2d} to point at.
    * @return this
    */
-  public SwerveInputStream aim(Pose2d aimTarget)
+  public SwerveInputStream aim(Pose2d aimPose)
   {
-    this.aimTarget = aimTarget.equals(Pose2d.kZero) ? Optional.empty() : Optional.of(aimTarget);
+    aim(() -> (aimPose));
+    return this;
+  }
+
+  public SwerveInputStream aim(Supplier<Pose2d> aimTarget)
+  {
+    this.aimTarget = aimTarget.get().equals(Pose2d.kZero) ? Optional.empty() : Optional.of(aimTarget);
     return this;
   }
 
@@ -1120,7 +1126,7 @@ public class SwerveInputStream implements Supplier<ChassisSpeeds>
       }
       case AIM ->
       {
-        var targetVector = getTargetVector(aimTarget.orElseThrow());
+        var targetVector = getTargetVector(aimTarget.orElseThrow().get());
         var targetDistance = targetVector.getNorm();
         // TODO: Shoot on the move, using
         //  targetVector = targetVector.div(targetDistance).times(sotmDistanceToRPSMap.get(targetDistance)*flyWheelCircumference)


### PR DESCRIPTION
Added an overload where .aim takes in a normal pose2d if needed

Only affected methods were .aim and the aim case in .get

aimTarget is now an Optional<Supplier<Pose2d>>